### PR TITLE
fix: remove module from ModuleLoader cache map on promise reject

### DIFF
--- a/src/util/module-loader.ts
+++ b/src/util/module-loader.ts
@@ -32,7 +32,10 @@ export class ModuleLoader {
     let promise = this._promiseMap.get(modulePath);
     if (!promise) {
       promise = this._ngModuleLoader.load(splitString[0], splitString[1]);
-      this._promiseMap.set(modulePath, promise);
+      promise.catch(() => {
+          this._promiseMap.delete(modulePath);
+      });
+      this._promiseMap.set(modulePath, promise);         
     }
 
     return promise.then(loadedModule => {


### PR DESCRIPTION
#### Short description of what this resolves:
Module loader is trying to cache loaded module in map.
After that, when loading page having lazy loading feature, module loader try to get from map instead of loading new for performance reason.
But when module loader failed to loaded lazy chunk (network probs..etc), it should try it again instead of get from map.
On promise reject call back of module loader, remove module from cache.

Ionic Version: 3.x

**Fixes**: #13639